### PR TITLE
Defaulting all the supported lang engines

### DIFF
--- a/R/klippy.R
+++ b/R/klippy.R
@@ -47,7 +47,7 @@ NULL
 #' rmarkdown::render(tf[1], "html_document", tf[2])
 #'
 #' @export
-klippy <- function(lang = c("r", "markdown"),
+klippy <- function(lang = c("r", "markdown", "python", "bash", "sql", "Rcpp", "stan", "js", "css", "julia", "c", "fortran", "awk", "ruby", "haskell", "perl", "dot", "tikz", "sas", "coffee", "go"),
                    all_precode = FALSE,
                    position = c("top", "left"),
                    color = "auto",


### PR DESCRIPTION
* Added [officially supported language engines](https://github.com/yihui/knitr-examples) to `lang` param by default so that other languages (e.g., python, etc.) can be included for the code copy; I think this minimizes users' confusion.