### PR TITLE
Adding a `size` parameter to `klippy()`, solving #18 and #27

### DIFF
--- a/R/klippy.R
+++ b/R/klippy.R
@@ -51,6 +51,7 @@ klippy <- function(lang = c("r", "markdown"),
                    all_precode = FALSE,
                    position = c("top", "left"),
                    color = "auto",
+                   size = NULL,
                    tooltip_message = "Copy code",
                    tooltip_success = "Copied!") {
 
@@ -153,11 +154,27 @@ klippy <- function(lang = c("r", "markdown"),
     sep = '\n'
   )
 
+  #' @param size size in pixels of the klippy button.
+  #' If `NULL`, an automatic size is used instead.
+  if (!is.null(size)){
+    assertthat::assert_that(
+      assertthat::is.scalar(size),
+      assertthat::see_if(size > 0)
+    )
+
+    tagList = htmltools::tagList(
+      htmltools::tags$style( paste0('pre{padding-', handside, ':', size, 'px}') ),
+      htmltools::tags$script(js_script))
+  } else {
+    tagList = htmltools::tags$script(js_script)
+  }
+
   #' @return An HTML tag object that can be rendered as HTML using
   #' [as.character()].
   # Attach dependencies to JS script:
+
   htmltools::attachDependencies(
-    htmltools::tags$script(js_script),
+    tagList,
     klippy_dependencies()
   )
 }

--- a/man/klippy.Rd
+++ b/man/klippy.Rd
@@ -9,6 +9,7 @@ klippy(
   all_precode = FALSE,
   position = c("top", "left"),
   color = "auto",
+  size = NULL,
   tooltip_message = "Copy code",
   tooltip_success = "Copied!"
 )
@@ -34,6 +35,9 @@ specifications, i.e., either a color name (as listed by
 (see \code{\link[grDevices:rgb]{grDevices::rgb()}}), or a positive integer \code{i}
 meaning \verb{[palette][grDevices::palette]()[i]}. Default value is
 \code{"auto"}: color is set to the anchor color of the document.}
+
+\item{size}{size in pixels of the klippy button.
+If \code{NULL}, an automatic size is used instead.}
 
 \item{tooltip_message}{String with the tooltip message.}
 


### PR DESCRIPTION
@RLesur Thanks for this very nice package! It is very useful, but the klippy button is a bit small compared to my taste (as in #18, #27) .

This PR adds a new parameter `size` (in pixels) to the function `klippy()`, allowing the user to customize the size (by changing the width) of the button. By default, this size is set to `NULL` and the (existing) automatic default is used instead.

In the `klippy.js` file, there is a function `autoSize` that computes the size of the klippy icon based on the left- or right-padding of the parent. This commit adjusts automatically this padding and therefore the size of the icon, from a `size` parameter given by the user.